### PR TITLE
[api ] 스마트매칭 로직 추가 (추후 로직 수정 예정)

### DIFF
--- a/ma-api/src/main/java/me/myarmy/api/controller/CategoryController.java
+++ b/ma-api/src/main/java/me/myarmy/api/controller/CategoryController.java
@@ -8,10 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -75,6 +72,13 @@ public class CategoryController {
     @GetMapping("/createdDate")
     public MaApiResponse<List<Object>> disCreatedDate(){
         List<Object> list = this.categoryService.createdDate();
+        return new MaApiResponse<>(list);
+    }
+
+    @GetMapping("/smartMatch/{uid:.+}")
+    public MaApiResponse<List<Object>> disSmartMatch(@PathVariable String uid){
+        logger.info("uid : ", uid);
+        List<Object> list = this.categoryService.smartMatch(uid);
         return new MaApiResponse<>(list);
     }
 }

--- a/ma-api/src/main/java/me/myarmy/api/repository/ResumeRepository.java
+++ b/ma-api/src/main/java/me/myarmy/api/repository/ResumeRepository.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
+    Resume findByUid(String uid);
 }

--- a/ma-api/src/main/java/me/myarmy/api/service/CategoryService.java
+++ b/ma-api/src/main/java/me/myarmy/api/service/CategoryService.java
@@ -1,6 +1,8 @@
 package me.myarmy.api.service;
 
 import lombok.extern.slf4j.Slf4j;
+import me.myarmy.api.domain.Resume;
+import me.myarmy.api.repository.ResumeRepository;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.DataFrame;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +23,9 @@ public class CategoryService {
     /* xml 정보 */
     @Autowired
     private DataFrame rootDataFrame;
+
+    @Autowired
+    private ResumeRepository resumeRepository;
 
     /***** 지역별 *****/
     @Cacheable(value="findJobAreaCache", key="#area")
@@ -61,4 +66,17 @@ public class CategoryService {
         return Arrays.asList(this.rootDataFrame.sort(ccdatabalsaengDtm.desc()).toJSON().collect());
     }
 
+    /****스마트 매칭****/
+    public List<Object> smartMatch(String uid){
+        log.debug(uid);
+        Resume resume = this.resumeRepository.findByUid(uid);
+        log.debug(resume.getObjective());
+        log.debug(resume.getAddress());
+        Column cjhakryeok = this.rootDataFrame.col("cjhakryeok");
+        Column eopjongGbcdNm = this.rootDataFrame.col("eopjongGbcdNm");
+        Column geunmujy = this.rootDataFrame.col("geunmujy");
+
+
+        return Arrays.asList(this.rootDataFrame.filter(cjhakryeok.contains(resume.getGrade())).filter(eopjongGbcdNm.contains(resume.getObjective())).filter(geunmujy.contains(resume.getAddress())).toJSON().collect());
+    }
 }


### PR DESCRIPTION
업종, 최종학력, 근무지 같은 기업리스트 리턴
최종학력의 경우 "고등학교중퇴 이상"이라면 "대졸"도 리턴해야 하기 때문에 로직 수정 필요
근무지의 경우 사용자가 이력서를 등록할 때 동까지만 입력하도록 통일시켜야 할 것 같음